### PR TITLE
catches error on unexpected termination of connection

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,4 +45,9 @@ var server = net.createServer(function(conn) {
 		}
 	})
 	conn.write('# munin node at ' + os.hostname() + '\n')
+	process.once('uncaughtException', function(err){
+		if (err.errno === 'ECONNRESET'){
+			return;
+		}
+	});
 }).listen(4949, '::')

--- a/server.js
+++ b/server.js
@@ -49,5 +49,6 @@ var server = net.createServer(function(conn) {
 		if (err.errno === 'ECONNRESET'){
 			return;
 		}
+		throw( err );
 	});
 }).listen(4949, '::')


### PR DESCRIPTION
This minor bugfix catches the ECONNRESET error occuring e.g. when terminating an external process that's opened up a connection to the server. Without catching this the server crashes leaving the plugins empty until the next fetch interval.